### PR TITLE
remove Dockerfile, don't Docker publish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM node:6-slim

--- a/circle.yml
+++ b/circle.yml
@@ -9,10 +9,3 @@ compile:
 test:
   override:
   - make test
-deployment:
-  all:
-    branch: master
-    owner: Clever
-    commands:
-    - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
-    - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME


### PR DESCRIPTION
This is a library, not an app, so it shouldn't publish a Docker image
nor a Catapult build.