### PR TITLE
Move compiled code to `dist` directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@clever/{{.AppName}}",
   "version": "0.0.1",
   "description": "{{.Description}}",
-  "main": "lib/index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --dist",
     "test": "jest"
   },
   "jest": {


### PR DESCRIPTION
Based on the [.gitignore](https://github.com/Clever/template-node-library/blob/master/.gitignore#L14), it seems like the original intention was to put all compiled javascript into the `dist` folder