### PR TITLE
Remove noImplicitAny: false to get full strictness

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
         "module": "commonjs",
         "target": "es6",
         "strict": true,
-        "noImplicitAny": false,
         "lib": ["es2017"],
         "typeRoots": [
             "node_modules/@types", "./types"


### PR DESCRIPTION
We previously added `strict` mode to the tsconfig, but left a `noImplicitAny: false` in which seems to take precedence over `strict`. This is bad since `noImplicitAny` is generally considered the most useful feature of strict mode. Now we get full strictness!