### PR TITLE
Set output directory to dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "lib": ["es2017"],
         "typeRoots": [
             "node_modules/@types", "./types"
-        ]
+        ],
+        "outDir": "./dist",
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
It looks like we generally output the generated files to a "dist" directory (for example this is what we do in clever-frontend-utils and field-templates). This updates the template's tsconfig to specify this.