### PR TITLE
Switch to referencing Clever's shared prettier config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,12 +1,1 @@
-{
-  "overrides": [
-    {
-      "files": "*",
-      "options": {
-        "trailingComma": "all",
-        "bracketSpacing": true,
-        "printWidth": 100
-      }
-    }
-  ]
-}
+"@clever/prettier-config"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@clever/prettier-config": "1.0.0",
     "@types/jest": "^18.1.1",
     "@types/node": "^12.12.24",
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/node-42

## Overview
Now that Clever has a [shared prettier config](https://github.com/Clever/prettier-config), let's reference that in the template so that new JS libraries use it 😄 .

## Testing
I tested this in sd2, and verified that formatting is unchanged.

## Rollout

## New Repo Setup
- [ ] Set up Slack notifications for this app for your team https://clever.atlassian.net/wiki/spaces/ENG/pages/888897571/GitHub+assignments
- [ ] Delete this section from the PR template
