### PR TITLE
Update make targets for formatting and linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,5 +19,6 @@ jobs:
         command: npm install
         name: npm install
     - run: make build
+    - run: make lint
     - run: make test
     - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN .; fi;

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,41 @@
 include node.mk
-.PHONY: all test build lint
+.PHONY: all test build format format-all format-check lint-es lint-fix lint
 SHELL := /bin/bash
 
-TS_FILES := $(shell find . -name "*.ts" -not -path "./node_modules/*" -not -name "*.d.ts")
+TS_FILES := $(shell find . -name "*.ts" -not -path "./node_modules/*")
+FORMATTED_FILES := $(TS_FILES) # Add other file types as you see fit, e.g. JSON files, config files
+MODIFIED_FORMATTED_FILES := $(shell git diff --name-only master $(FORMATTED_FILES))
+
+PRETTIER := ./node_modules/.bin/prettier
+ESLINT := ./node_modules/.bin/eslint
 
 all: test build
 
 format:
-	@./node_modules/.bin/prettier --write $(TS_FILES)
+	@echo "Formatting modified files..."
+	@$(PRETTIER) --write $(MODIFIED_FORMATTED_FILES)
 
-lint:
-	@echo "Linting..."
-	@./node_modules/.bin/eslint -c .eslintrc.yml $(TS_FILES)
-	@echo "Running prettier"
-	@./node_modules/.bin/prettier -l $(TS_FILES) || \
-		(echo "**** Prettier errors in the above files! Run 'make format' to fix! ****" && false)
+format-all:
+	@echo "Formatting all files..."
+	@$(PRETTIER) --write $(FORMATTED_FILES)
 
-test: lint
+format-check:
+	@echo "Running format check..."
+	@$(PRETTIER) --list-different $(FORMATTED_FILES) || \
+		(echo -e "❌ \033[0;31m Prettier found discrepancies in the above files. Run 'make format' to fix.\033[0m" && false)
+
+lint-es:
+	@echo "Running eslint..."
+	@$(ESLINT) $(TS_FILES)
+
+lint-fix:
+	@echo "Running eslint --fix"
+	@$(ESLINT) --fix $(TS_FILES) || \
+		(echo "\033[0;31mThe above errors require manual fixing.\033[0m" && true)
+
+lint: format-check lint-es
+
+test:
 	@echo "Testing..."
 	node_modules/.bin/jest
 


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/node-37

## Overview
This change updates the make targets for formatting and linting based on what's in some of Clever's most active JS repos. Now `make format` only formats modified files instead of every file. `make format` is what many engineers use in their workflow, so let's make sure it's fast. There's now also a `make format-all` which formats everything, which is useful when upgrading to the latest version of prettier. 

The prettier executable is stored as a variable in the Makefile to make it a little cleaner, and to make faster to do mass prettier upgrades using scripts. Instead of having to install prettier in a bunch of repos to run it, we can install prettier globally and  just update the package.json + package-lock.json in each repo. 

While I was in there, I also updated the targets for running the linter. I also switched the order so that running all the checks will run the format check first, then the linter. I personally prefer that order because I like to see the most trivial errors first, and sometimes formatting also fixes lint errors (maybe the linter  shouldn't complain about things that prettier fixes though). I'm interested in thoughts on the ordering of these checks. 

I did think about putting these in the node.mk file, but each of these targets is so small that it doesn't seem necessary. I also plan to backport these make targets to some existing repos in an effort to standardize formatting and linting commands.

## Testing

## Rollout

## New Repo Setup
- [ ] Set up Slack notifications for this app for your team https://clever.atlassian.net/wiki/spaces/ENG/pages/888897571/GitHub+assignments
- [ ] Delete this section from the PR template
