### PR TITLE
Grant CircleCI the ability to install private dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,18 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
       - run:
-          command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
           name: Clone ci-scripts
+          command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
       - checkout
       - run:
-          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
           name: Set up CircleCI artifacts directories
+          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - run:
-          command: npm install
-          name: npm install
+          name: Set up .npmrc
+          command: |
+            sed -i.bak s/\${npm_auth_token}/$NPM_TOKEN/ .npmrc_docker
+            mv .npmrc_docker .npmrc
+      - run: npm install
       - run: make build
       - run: make lint
       - run: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,22 @@ jobs:
   build:
     working_directory: ~/Clever/{{.AppName}}
     docker:
-    - image: circleci/node:12-stretch
+      - image: circleci/node:12-stretch
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
-    - run:
-        command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-        name: Clone ci-scripts
-    - checkout
-    - run:
-        command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-        name: Set up CircleCI artifacts directories
-    - run:
-        command: npm install
-        name: npm install
-    - run: make build
-    - run: make lint
-    - run: make test
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN .; fi;
+      - run:
+          command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+          name: Clone ci-scripts
+      - checkout
+      - run:
+          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+          name: Set up CircleCI artifacts directories
+      - run:
+          command: npm install
+          name: npm install
+      - run: make build
+      - run: make lint
+      - run: make test
+      - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN .; fi;

--- a/.npmrc_docker
+++ b/.npmrc_docker
@@ -1,0 +1,5 @@
+ca = null
+//registry.npmjs.org/:_authToken=${npm_auth_token}
+@clever:registry=https://registry.npmjs.org/
+always-auth = true
+strict-ssl = true

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "description": "{{.Description}}",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc --dist",
-    "test": "jest"
-  },
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
This PR mirrors https://github.com/Clever/template-frontend/pull/48. In addition to granting CircleCI the ability to install private dependencies, it also removes unused and out-of-date npm scripts.