### PR TITLE
add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: {{.AppName}}
+  description: {{.Description}}
+  owner: {{.TeamName}}
+spec:
+  type: library
+  lifecycle: production
+  owner: {{.TeamName}}
+  system: Clever


### PR DESCRIPTION
## Link to JIRA
https://clever.atlassian.net/browse/INFRANG-6887

## Overview
As part of creating template-go-library I have init-service now creating a catalog-info.yaml for backstage to consume. Doing the same here so that library templates can be treated the same in init-service. 

## Testing
Created repo locally. 

## Rollout

## New Repo Setup
- [ ] Set up Slack notifications for this app for your team https://clever.atlassian.net/wiki/spaces/ENG/pages/888897571/GitHub+assignments
- [ ] Delete this section from the PR template
